### PR TITLE
Revenue trends last entry has less data

### DIFF
--- a/Website/htdocs/mpmanager/app/Http/Services/PeriodService.php
+++ b/Website/htdocs/mpmanager/app/Http/Services/PeriodService.php
@@ -32,6 +32,12 @@ class PeriodService
         $end = date_create($endDate);
 
 
+        $daysDifference = $end->diff($begin)->days;
+
+        if ($interval === 'weekly' && $daysDifference % 7 !== 0) {
+            $end->add(new DateInterval('P' . ($daysDifference % 7) . 'D'));
+        }
+
         if ($end->diff($begin)->days % 365 === 0) {
             $end->add(new DateInterval('P1D'));
         }


### PR DESCRIPTION
The periodic date controller had some issues on weekly type. In some cases, the end date was not included in the periods. The result of that, incomplete chart data which prevent to generate the chart in the Mini-Grid Dashboard