### PR TITLE
Php 8  & Laravel 8 Upgrade

### DIFF
--- a/Docker/DockerfileCron
+++ b/Docker/DockerfileCron
@@ -1,7 +1,9 @@
-FROM php:7.3-apache
+FROM php:8-apache
 
 # Install cron
-RUN apt-get update && apt-get -y install cron \
+RUN apt-get update && \
+    apt-get install -y \
+    install cron \
     libjpeg-dev \
     libfreetype6-dev \
     libxml2-dev \
@@ -18,8 +20,8 @@ RUN apt-get update && apt-get -y install cron \
 RUN rm -rf /var/lib/apt/lists/*
 
 # install php extentions
-RUN docker-php-ext-install gd mysqli zip mbstring pdo pdo_mysql soap ftp opcache bcmath pcntl
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-png-dir=/usr --with-jpeg-dir=/usr \
+RUN docker-php-ext-install gd mysqli zip pdo pdo_mysql soap ftp opcache bcmath pcntl
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg\
 && docker-php-ext-configure pcntl --enable-pcntl
 
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## System Requirements
 
-PHP ^7.3
+PHP ^8.0
 
 Node ^v14.3
 
@@ -63,7 +63,7 @@ Change the `api_user`, `api_password`, and `ips` in `services.php`
         'ips' => [
             'ALLOWED_IPS TO SEND YOU TRANSACTION DATA'
         ],
-    ],
+    ]
 ```
 The following change should be done in the `.env` file
 ```bash

--- a/Website/htdocs/mpmanager/composer.json
+++ b/Website/htdocs/mpmanager/composer.json
@@ -8,31 +8,33 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3",
-        "doctrine/dbal": "2.10.1",
+        "php": "^8.0",
+        "doctrine/dbal": "^3.1",
+        "enlightn/enlightn": "^1.22",
         "fideloper/proxy": "^4.0",
-        "guzzlehttp/guzzle": "7.2.0",
-        "laravel/framework": "^7.0",
+        "guzzlehttp/guzzle": "^7.3.0",
+        "laravel/framework": "^8.12",
         "laravel/helpers": "^1.2",
-        "laravel/horizon": "^4.0",
-        "laravel/tinker": "^2.0",
-        "laravel/ui": "^2.0.3",
-        "mpociot/laravel-apidoc-generator": "^4.4",
+        "laravel/horizon": "^5.0",
+        "laravel/tinker": "^2.5",
+        "laravel/ui": "^3.2",
         "phpmailer/phpmailer": "^6.1.5",
-        "phpoffice/phpspreadsheet": "1.11.0",
-        "predis/predis": "1.1.1",
-        "pusher/pusher-php-server": "4.1.1",
-        "tymon/jwt-auth": "1.0.0",
-        "webpatser/laravel-uuid": "^3.0"
+        "phpoffice/phpspreadsheet": "^1.7",
+        "predis/predis": "^1.1.7",
+        "pusher/pusher-php-server": "^6.0",
+        "tymon/jwt-auth": "dev-develop",
+        "webpatser/laravel-uuid": "^4.0"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.5",
         "beyondcode/laravel-dump-server": "^1.0",
         "facade/ignition": "^2.0",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.9.1",
         "mockery/mockery": "^1.0",
-        "nunomaduro/collision": "^4.1",
-        "phpunit/phpunit": "^8.5",
+        "nunomaduro/collision": "^5.3",
+        "phpunit/phpunit": "^9.0",
+        "spatie/laravel-web-tinker": "^1.7",
         "squizlabs/php_codesniffer": "*",
         "vimeo/psalm": "^4.4"
     },
@@ -48,12 +50,10 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
-        },
-        "classmap": [
-            "database/seeds",
-            "database/factories"
-        ]
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/Website/htdocs/mpmanager/config/mail.php
+++ b/Website/htdocs/mpmanager/config/mail.php
@@ -1,15 +1,110 @@
 <?php
 
-
-use PHPMailer\PHPMailer\PHPMailer;
-
 return [
-    'host' => '', //your host to send through
-    'smtp_auth' => true, // enable SMTP authentication
-    'username' => '',// SMTP username
-    'password' => '', //SMTP username
-    'smtp_secure' => PHPMailer::ENCRYPTION_STARTTLS,// default is tls
-    'port' => '',
-    'default_sender' => '',
-    'default_message' => 'Please do not reply to this email', // adds a small footer text to your email
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Mailer
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default mailer that is used to send any email
+    | messages sent by your application. Alternative mailers may be setup
+    | and used as needed; however, this mailer will be used by default.
+    |
+    */
+
+    'default' => env('MAIL_MAILER', 'smtp'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mailer Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure all of the mailers used by your application plus
+    | their respective settings. Several examples have been configured for
+    | you and you are free to add your own as your application requires.
+    |
+    | Laravel supports a variety of mail "transport" drivers to be used while
+    | sending an e-mail. You will specify which one you are using for your
+    | mailers below. You are free to add additional mailers as required.
+    |
+    | Supported: "smtp", "sendmail", "mailgun", "ses",
+    |            "postmark", "log", "array"
+    |
+    */
+
+    'mailers' => [
+        'smtp' => [
+            'transport' => 'smtp',
+            'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
+            'port' => env('MAIL_PORT', 587),
+            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+            'username' => env('MAIL_USERNAME'),
+            'password' => env('MAIL_PASSWORD'),
+            'timeout' => null,
+            'auth_mode' => null,
+        ],
+
+        'ses' => [
+            'transport' => 'ses',
+        ],
+
+        'mailgun' => [
+            'transport' => 'mailgun',
+        ],
+
+        'postmark' => [
+            'transport' => 'postmark',
+        ],
+
+        'sendmail' => [
+            'transport' => 'sendmail',
+            'path' => '/usr/sbin/sendmail -bs',
+        ],
+
+        'log' => [
+            'transport' => 'log',
+            'channel' => env('MAIL_LOG_CHANNEL'),
+        ],
+
+        'array' => [
+            'transport' => 'array',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Global "From" Address
+    |--------------------------------------------------------------------------
+    |
+    | You may wish for all e-mails sent by your application to be sent from
+    | the same address. Here, you may specify a name and address that is
+    | used globally for all e-mails that are sent by your application.
+    |
+    */
+
+    'from' => [
+        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+        'name' => env('MAIL_FROM_NAME', 'Example'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Markdown Mail Settings
+    |--------------------------------------------------------------------------
+    |
+    | If you are using Markdown based email rendering, you may configure your
+    | theme and component paths here, allowing you to customize the design
+    | of the emails. Or, you may simply stick with the Laravel defaults!
+    |
+    */
+
+    'markdown' => [
+        'theme' => 'default',
+
+        'paths' => [
+            resource_path('views/vendor/mail'),
+        ],
+    ],
+
 ];

--- a/Website/htdocs/mpmanager/database/factories/VodacomTransactionFactory.php
+++ b/Website/htdocs/mpmanager/database/factories/VodacomTransactionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Transaction\VodacomTransaction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class VodacomTransactionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = VodacomTransaction::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => $this->faker->unique()->randomNumber(),
+            'originator_conversation_id' => $this->faker->unique(true)->randomNumber(),
+            'mpesa_receipt' => $this->faker->name(),
+            'transaction_date' => $this->faker->dateTime(),
+            'transaction_id' => $this->faker->unique()->randomNumber(),
+            'status' => 0,
+        ];
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/ConnectionGroupSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/ConnectionGroupSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ConnectionGroupSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('connection_groups')->insert([
+            'name' => 'default connection group',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/ConnectionTypeSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/ConnectionTypeSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ConnectionTypeSeeder extends Seeder
+{
+
+
+    public function run(): void
+    {
+        DB::table('connection_types')->insert([
+            'name' => 'default connection type',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/DatabaseSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->call(UserSeeder::class);
+        $this->call(ConnectionTypeSeeder::class);
+        $this->call(ManufacturerSeeder::class);
+        $this->call(SubConnectionTypeSeeder::class);
+        $this->call(MenuItemsSeeder::class);
+        $this->call(SubMenuItemsSeeder::class);
+        $this->call(ConnectionGroupSeeder::class);
+        $this->call(MainSettingsSeeder::class);
+        $this->call(MapSettingsSeeder::class);
+        $this->call(TicketSettingsSeeder::class);
+        $this->call(SmsBodiesSeeder::class);
+        $this->call(SmsResendInformationKeySeeder::class);
+        $this->call(SmsVariableDefaultValuesSeeder::class);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/MainSettingsSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/MainSettingsSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class MainSettingsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('main_settings')->insert([
+            'site_title' => 'MPM - The easiest way to manage your Mini-Grid',
+            'company_name' => 'MicroPowerManager',
+            'currency' => '€',
+            'country' => 'Germany',
+            'vat_energy' => 1,
+            'vat_appliance' => 18,
+            'language' => 'en',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/ManufacturerSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/ManufacturerSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+class ManufacturerSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('manufacturers')->insert([
+            'name' => 'Calin Meters STS',
+            'website' => 'http://www.calinmeter.com/',
+            'api_name' => 'CalinApi',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/MapSettingsSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/MapSettingsSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class MapSettingsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('map_settings')->insert([
+            'zoom' => 7,
+            'latitude' => -2.500380,
+            'longitude' => 32.889060,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/MenuItemsSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/MenuItemsSeeder.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class MenuItemsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('menu_items')->insert(array(
+                [
+                    'name' => 'Dashboard',
+                    'url_slug' => '',
+                    'md_icon' => 'home',
+                    'menu_order' => '1',
+
+                ],
+                [
+                    'name' => 'Customers',
+                    'url_slug' => '/people/page/1',
+                    'md_icon' => 'supervisor_account',
+                    'menu_order' => '2',
+                ],
+                [
+                    'name' => 'Agents',
+                    'url_slug' => '',
+                    'md_icon' => 'support_agent',
+                    'menu_order' => '3',
+                ],
+                [
+                    'name' => 'Meters',
+                    'url_slug' => '',
+                    'md_icon' => 'bolt',
+                    'menu_order' => '4',
+                ],
+                [
+                    'name' => 'Transactions',
+                    'url_slug' => '/transactions/page/1',
+                    'md_icon' => 'account_balance',
+                    'menu_order' => '5',
+                ],
+                [
+                    'name' => 'Tickets',
+                    'url_slug' => '',
+                    'md_icon' => 'confirmation_number',
+                    'menu_order' => '6',
+                ],
+                [
+                    'name' => 'Tariffs',
+                    'url_slug' => '/tariffs',
+                    'md_icon' => 'widgets',
+                    'menu_order' => '7',
+                ],
+                [
+                    'name' => 'Targets',
+                    'url_slug' => '/targets',
+                    'md_icon' => 'gps_fixed',
+                    'menu_order' => '8',
+                ],
+                [
+                    'name' => 'Reports',
+                    'url_slug' => '/reports',
+                    'md_icon' => 'text_snippet',
+                    'menu_order' => '9',
+                ],
+                [
+                    'name' => 'Sms',
+                    'url_slug' => '',
+                    'md_icon' => 'sms',
+                    'menu_order' => '10',
+                ],
+                [
+                    'name' => 'Asset Types',
+                    'url_slug' => '/assets/types/page/1',
+                    'md_icon' => 'devices_other',
+                    'menu_order' => '11',
+                ],
+                [
+                    'name' => 'Maintenance',
+                    'url_slug' => '/maintenance',
+                    'md_icon' => 'home_repair_service',
+                    'menu_order' => '12',
+                ],
+
+
+            )
+        );
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/SmsBodiesSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/SmsBodiesSeeder.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SmsBodiesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('sms_bodies')->insert(array(
+                [
+                    'reference' => 'SmsTransactionHeader',
+                    'place_holder' => 'Dear [name] [surname], we received your transaction [transaction_amount].',
+                    'variables'=>'name,surname,transaction_amount',
+                    'title'=>'Sms Header'
+                ],
+                [
+                    'reference' => 'SmsReminderHeader',
+                    'place_holder' => 'Dear [name] [surname],',
+                    'variables'=>'name,surname',
+                    'title'=>'Sms Header'
+                ],
+                [
+                    'reference' => 'SmsResendInformationHeader',
+                    'place_holder' => 'Dear [name] [surname], we received your resend last transaction information demand.',
+                    'variables'=>'name,surname',
+                    'title'=>'Sms Header'
+                ],
+                [
+                    'reference' => 'EnergyConfirmation',
+                    'place_holder' =>  'Meter: [meter] , [token]  Unit [energy] .',
+                    'variables'=>'meter,token,energy',
+                    'title'=>'Meter Charge'
+                ],
+                [
+                    'reference' => 'AccessRateConfirmation',
+                    'place_holder' =>  'Service Charge: [amount] ',
+                    'variables'=>'amount',
+                    'title'=>'Tariff Fixed Cost'
+                ],
+                [
+                    'reference' => 'AssetRateReminder',
+                    'place_holder' =>  'the next rate of  [appliance_type_name] ( . [remaining] . ) is due on [due_date]',
+                    'variables'=>'appliance_type_name,remaining,due_date',
+                    'title'=>'Appliance Payment Reminder'
+
+                ],
+                [
+                    'reference' => 'AssetRatePayment',
+                    'place_holder' => 'Appliance:   [appliance_type_name]  [amount]',
+                    'variables'=>'appliance_type_name,amount',
+                    'title'=>'Appliance Payment'
+                ],
+                [
+                    'reference' => 'OverdueAssetRateReminder',
+                    'place_holder' => 'you forgot to pay the rate of [appliance_type_name] ( [remaining] )  on [due_date]. Please pay it as soon as possible, unless you wont be able to buy energy.',
+                    'variables'=>'appliance_type_name,remaining,due_date',
+                    'title'=>'Overdue Appliance Payment Reminder'
+                ],
+                [
+                    'reference' => 'PricingDetails',
+                    'place_holder' => 'Transaction amount is [amount], \n VAT for energy : [vat_energy] \n VAT for the other staffs : [vat_others] . ',
+                    'variables'=>'amount,vat_energy,vat_others',
+                    'title'=>'Pricing Details'
+                ],
+                [
+                    'reference' => 'ResendInformation',
+                    'place_holder' =>  'Meter: [meter] , [token]  Unit [energy] KWH. Service Charge: [amount]',
+                    'variables'=>'meter,token,energy,amount',
+                    'title'=>'Resend Last Transaction Information'
+                ],
+                [
+                    'reference' => 'ResendInformationLastTransactionNotFound',
+                    'place_holder' =>  'Last transaction information not found for Meter: [meter]',
+                    'variables'=>'meter',
+                    'title'=>'Last Transaction Information Not Found'
+                ],
+                [
+                    'reference' => 'SmsReminderFooter',
+                    'place_holder' => 'Your Company etc.',
+                    'variables'=>'',
+                    'title'=>'Sms Footer'
+                ],
+                [
+                    'reference' => 'SmsTransactionFooter',
+                    'place_holder' => 'Your Company etc.',
+                    'variables'=>'',
+                    'title'=>'Sms Footer'
+                ],
+                [
+                    'reference' => 'SmsResendInformationFooter',
+                    'place_holder' => 'Your Company etc.',
+                    'variables'=>'',
+                    'title'=>'Sms Footer'
+                ],
+
+
+            )
+        );
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/SmsResendInformationKeySeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/SmsResendInformationKeySeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SmsResendInformationKeySeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('sms_resend_information_keys')->insert(['key' => 'Resend']);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/SmsVariableDefaultValuesSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/SmsVariableDefaultValuesSeeder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SmsVariableDefaultValuesSeeder extends Seeder
+{
+
+    public function run()
+    {
+        DB::table('sms_variable_default_values')->insert(array(
+                [
+                    'variable' => 'name',
+                    'value' => 'Herbert',
+                ],
+                [
+                    'variable' => 'surname',
+                    'value' => 'Kale',
+                ],
+                [
+                    'variable' => 'amount',
+                    'value' => '1000',
+                ],
+                [
+                    'variable' => 'appliance_type_name',
+                    'value' => 'fridge',
+                ],
+                [
+                    'variable' => 'remaining',
+                    'value' => '3',
+                ],
+                [
+                    'variable' => 'due_date',
+                    'value' => '2021/04/01',
+                ],
+                [
+                    'variable' => 'meter',
+                    'value' => '47782371232',
+                ],
+                [
+                    'variable' => 'token',
+                    'value' => '5111 3511 9911 1177 7711',
+                ],
+                [
+                    'variable' => 'vat_energy',
+                    'value' => '15',
+                ],
+                [
+                    'variable' => 'vat_others',
+                    'value' => '10',
+                ],
+                [
+                    'variable' => 'energy',
+                    'value' => '5123.1',
+                ],[
+                    'variable' => 'transaction_amount',
+                    'value' => '500',
+                ],
+            )
+        );
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/SubConnectionTypeSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/SubConnectionTypeSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SubConnectionTypeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('sub_connection_types')->insert([
+            'name' => 'default  sub connection type',
+            'tariff_id' => 1,
+            'connection_type_id' => 1,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/SubMenuItemsSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/SubMenuItemsSeeder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SubMenuItemsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('sub_menu_items')->insert(array(
+                [
+                    'name' => 'Clusters',
+                    'url_slug' => '/',
+                    'parent_id' => '1',
+                ],
+                [
+                    'name' => 'Mini-Grid',
+                    'url_slug' => '/dashboards/mini-grid',
+                    'parent_id' => '1',
+                ],
+                [
+                    'name' => 'List',
+                    'url_slug' => '/agents/page/1',
+                    'parent_id' => '3',
+                ],
+                [
+                    'name' => 'Commission Types',
+                    'url_slug' => '/commissions',
+                    'parent_id' => '3',
+                ],
+                [
+                    'name' => 'List',
+                    'url_slug' => '/meters/page/1',
+                    'parent_id' => '4',
+                ],
+                [
+                    'name' => 'Types',
+                    'url_slug' => '/meters/types',
+                    'parent_id' => '4',
+                ],
+                [
+                    'name' => 'List',
+                    'url_slug' => '/tickets',
+                    'parent_id' => '6',
+                ],
+                [
+                    'name' => 'Users',
+                    'url_slug' => '/tickets/settings/users',
+                    'parent_id' => '6',
+                ],
+                [
+                    'name' => 'Categories',
+                    'url_slug' => '/tickets/settings/categories',
+                    'parent_id' => '6',
+                ],
+                [
+                    'name' => 'Sms List',
+                    'url_slug' => '/sms/list',
+                    'parent_id' => '10',
+                ],
+                [
+                    'name' => 'New Sms',
+                    'url_slug' => '/sms/newsms',
+                    'parent_id' => '10',
+                ],
+            )
+        );
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/TicketSettingsSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/TicketSettingsSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TicketSettingsSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('ticket_settings')->insert([
+            'name' => 'Trello',
+            'api_token' => '----',
+            'api_url' => 'https://api.trello.com/1',
+            'api_key' => '----',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/Website/htdocs/mpmanager/database/seeders/UserSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/UserSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('users')->insert([
+            'name' => 'Admin',
+            'email' => 'admin@admin.com',
+            'password' => Hash::make('basic-password'),
+        ]);
+    }
+}

--- a/docker-compose-prod-non-domain.yml
+++ b/docker-compose-prod-non-domain.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: Docker/
       dockerfile: DockerfileLaravelProd
-    image: laravel/php:73
+    image: laravel/php:8
     container_name: laravel
     restart: unless-stopped
     depends_on:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: Docker/
       dockerfile: DockerfileLaravelProd
-    image: laravel/php:73
+    image: laravel/php:8
     restart: unless-stopped
     container_name: laravel
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: Docker/
       dockerfile: DockerfileLaravelDev
-    image: laravel/php:73
+    image: laravel/php:8
 
     environment:
       VIRTUAL_HOST: mpmanager.local


### PR DESCRIPTION
### PHP8
The php images in the docker files updated with php8 images. 
The laravel:php73 container name updated with laravel:php8 to make it clearer which version of php is been used.

The php version in the readme file also changed.


### Laravel8
The seeders and fakers adapted according to the upgrade documentation. 
The mail config file also updated with the Laravel  V8 one.