### PR TITLE
ohmyzsh support for local docker file

### DIFF
--- a/Docker/DockerfileLaravelDev
+++ b/Docker/DockerfileLaravelDev
@@ -13,7 +13,17 @@ RUN apt-get update && \
     supervisor \
     libzip-dev \
     vim \
-    git
+    git \
+    zsh
+
+
+# install ohmyzsh
+RUN chsh -s $(which zsh)
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# add php artisan alias
+RUN echo 'alias "cmd=php artisan"'  >> ~/.zshrc
+
 
 # remove apt lists
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adding  `zsh`  for the local development dockerfile.  
This PR also introduces the  `cmd` alias which is pointing to `php artisan`.


Usage:  Login to the laravel container with `docker exec -it laravel zsh`

![image](https://user-images.githubusercontent.com/9267638/128631672-0cb57769-87a5-4e4a-8fc8-34c8fad9bd79.png)
