### PR TITLE
Payment type is changed for payment history

### DIFF
--- a/Website/htdocs/mpmanager/app/Listeners/SoldApplianceListener.php
+++ b/Website/htdocs/mpmanager/app/Listeners/SoldApplianceListener.php
@@ -41,7 +41,7 @@ class SoldApplianceListener
                     'amount' => $transaction->amount,
                     'paymentService' =>
                         $transaction->original_transaction_type === 'cash_transaction' ? 'web' : 'agent',
-                    'paymentType' => 'appliance',
+                    'paymentType' => 'down payment',
                     'sender' => $transaction->sender,
                     'paidFor' => $assetType,
                     'payer' => $buyer,


### PR DESCRIPTION
Changed payment type from appliance to down payment when creating a payment history to sell appliance with down payment.