### PR TITLE
Minor bug fixed.

### DIFF
--- a/Website/htdocs/mpmanager/app/Relations/BelongsToMorph.php
+++ b/Website/htdocs/mpmanager/app/Relations/BelongsToMorph.php
@@ -46,7 +46,10 @@ class BelongsToMorph extends BelongsTo
      * @param  array|mixed $columns
      * @return Builder
      */
-    public function getRelationQueryDeprecated(Builder $query, Builder $parent, $columns = ['*'])
+    /**
+     * @deprecated
+     **\
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         $table = $this->getParent()->getTable();
         $query = parent::getRelationQuery($query, $parent, $columns);


### PR DESCRIPTION
getRelationQuery function is marked as deprecated for preventing relation query conflicts on laravel8.